### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -35,6 +35,10 @@ endif
 
 TARGET_NAME := vecx
 LIBM := 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 ifeq ($(ARCHFLAGS),)
 ifeq ($(archs),ppc)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 CORE_DIR     := ..
 LIBRETRO_DIR := ../libretro
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -59,7 +59,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
 	memset(info, 0, sizeof(*info));
 	info->library_name = "VecX";
-	info->library_version = "1.2";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+	info->library_version = "1.2" GIT_VERSION;
 	info->need_fullpath = false;
 	info->valid_extensions = "bin|vec";
 }


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.