### PR TITLE
use "uname -s" for platform detection - fixes #19

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -3,33 +3,33 @@ FRONTEND_SUPPORTS_RGB565=1
 
 ifeq ($(platform),)
 platform = unix
-ifeq ($(shell uname -a),)
+ifeq ($(shell uname -s),)
    platform = win
-else ifneq ($(findstring MINGW,$(shell uname -a)),)
+else ifneq ($(findstring MINGW,$(shell uname -s)),)
    platform = win
-else ifneq ($(findstring Darwin,$(shell uname -a)),)
+else ifneq ($(findstring Darwin,$(shell uname -s)),)
    platform = osx
    arch = intel
 ifeq ($(shell uname -p),powerpc)
    arch = ppc
 endif
-else ifneq ($(findstring win,$(shell uname -a)),)
+else ifneq ($(findstring win,$(shell uname -s)),)
    platform = win
 endif
 endif
 
 # system platform
 system_platform = unix
-ifeq ($(shell uname -a),)
+ifeq ($(shell uname -s),)
 EXE_EXT = .exe
    system_platform = win
-else ifneq ($(findstring Darwin,$(shell uname -a)),)
+else ifneq ($(findstring Darwin,$(shell uname -s)),)
    system_platform = osx
    arch = intel
 ifeq ($(shell uname -p),powerpc)
    arch = ppc
 endif
-else ifneq ($(findstring MINGW,$(shell uname -a)),)
+else ifneq ($(findstring MINGW,$(shell uname -s)),)
    system_platform = win
 endif
 


### PR DESCRIPTION
* avoids issues if hostname contains the string "win" for example

Would be useful to have this tested by someone on OSX / Windows to make sure it's ok before merging. Other libretro cores are affected too.