### PR TITLE
Fix unterminated input descriptors

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -187,6 +187,8 @@ bool retro_load_game(const struct retro_game_info *info)
       { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "1" },
       { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "3" },
       { 1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "4" },
+
+      { 0 }
    };
 
    if (!info)


### PR DESCRIPTION
According to libretro.h:

```
The array is terminated by retro_input_descriptor::description being set to NULL.
```

Fixes https://github.com/kodi-game/game.libretro.vecx/issues/6