### PR TITLE
(CTR) Update rules / Disable internal resolution multiplier

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -161,8 +161,11 @@ else ifeq ($(platform), ctr)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
-   CFLAGS += -D_3DS
-   STATIC_LINKING = 1
+   	CFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard
+	CFLAGS += -Wall -mword-relocations
+	CFLAGS += -fomit-frame-pointer -ffast-math
+	CFLAGS += -D_3DS
+	STATIC_LINKING = 1
 
 else ifeq ($(platform), xenon)
    TARGET := $(TARGET_NAME)_libretro_xenon360.a

--- a/libretro.c
+++ b/libretro.c
@@ -22,7 +22,12 @@
 
 static int WIDTH = 330;
 static int HEIGHT = 410;
+
+#ifdef _3DS
+#define BUFSZ 135300
+#else
 #define BUFSZ 2164800
+#endif
 
 static retro_video_refresh_t video_cb;
 static retro_input_poll_t poll_cb;
@@ -97,8 +102,14 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 	info->timing.sample_rate    = 44100;
 	info->geometry.base_width   = WIDTH;
 	info->geometry.base_height  = HEIGHT;
+#ifdef _3DS
+	info->geometry.max_width    = 330;
+	info->geometry.max_height   = 410;
+#else
 	info->geometry.max_width    = 1320;
 	info->geometry.max_height   = 1640;
+#endif
+		
 	info->geometry.aspect_ratio = 3.0 / 4.0;
 }
 


### PR DESCRIPTION
Tested and working on a new3ds.

The updated rules fixes the build issues. 
[https://github.com/MrHuu/libretro-vecx/commit/096a8f08035ee9f7dde498e8833db0d6e017e77f](https://github.com/MrHuu/libretro-vecx/commit/096a8f08035ee9f7dde498e8833db0d6e017e77f)

However, nothing is being rendered to the screen once a rom is loaded.
The sound is working, and the core is running at about 20fps.

Disabling or limiting the internal resolution multiplier ( #13 ) and restoring BUFSZ to it's original size fixes the issue of the black screen.
[https://github.com/MrHuu/libretro-vecx/commit/dd089c80ec36962323272f5c6601a61c574d5081](https://github.com/MrHuu/libretro-vecx/commit/dd089c80ec36962323272f5c6601a61c574d5081)

With vsync disabled the core runs at a stable 50fps.
The unusual resolution of the original hardware doesn't get to it's full potential on the 240x400 screen, but the core runs fine otherwise.