### PR TITLE
Fixed colour conversion (7 bit mono to RGB1555).

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -248,7 +248,11 @@ void retro_reset(void)
 	e8910_init_sound();
 }
 
-#define RGB1555(col) ( (col) << 10 | (col) << 5 | (col) )
+static INLINE uint16_t RGB1555(int col)
+{
+    col >>= 2;  /* Lose the bottom two bits because we are squeezing 7 bits of colour into 5. */
+    return col << 10 | col << 5 | col;
+}
 
 static INLINE void draw_point(int x, int y, unsigned char col)
 {


### PR DESCRIPTION
The previous version tried to expand 7 bit Vectrex colours into RGB1555 but failed to take into account it only had 5 bits to put them in. This resulted in the two most significant bits overflowing into the next colour. It's not visible on most games because they only use full brightness. The effect of the problem and solution can be most clearly seen on the test.bin ROM's intensity page which tries to display all 128 intensity levels.