### PR TITLE
libretro: fix GLES hw context initialization

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -341,7 +341,7 @@ static void context_destroy(void)
    }
 }
 
-#ifdef GLES  
+#ifdef HAVE_OPENGLES
 static bool retro_init_hw_context(bool useHardwareContext)
 {
    if (useHardwareContext)


### PR DESCRIPTION
The initial GPU rendering commit used `HAVE_OPENGLES` to initialise the HW context for GLES,
but this was changed in c3b68dc954a1a4798c503f5bc2ad744c63724cdb. However, the Makefile doesn't add `-DGLES` to CFLAGS , but `-DHAVE_OPENGLES[2,3]`.

This fixes GLES context initialization for the core, otherwise it will always attempt to request an OpenGL context:

    ...
    [INFO] [Environ]: SET_HW_RENDER.
    [ERROR] Requesting OpenGL context, but RetroArch is compiled against OpenGLES. Cannot use HW context.
    ...