### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -337,13 +337,21 @@ else ifneq (,$(findstring armv,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so
    SHARED := -shared -Wl,--no-undefined
    fpic := -fPIC
-   CC = gcc
+   CC ?= gcc
    ifneq (,$(findstring cortexa8,$(platform)))
       CFLAGS += -marm -mcpu=cortex-a8
       ASFLAGS += -mcpu=cortex-a8
    else ifneq (,$(findstring cortexa9,$(platform)))
       CFLAGS += -marm -mcpu=cortex-a9
       ASFLAGS += -mcpu=cortex-a9
+   endif
+   ifeq ($(HAS_GPU), 1)
+      ifeq ($(HAS_GLES), 1)
+         GL_LIB := -lGLESv2
+         GLES :=1
+      else
+         GL_LIB := -lGL
+      endif
    endif
    CFLAGS += -marm
    ifneq (,$(findstring neon,$(platform)))


### PR DESCRIPTION
"armv" platform is recognized by the makefile, but actual compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts), due to GL link errors.

Added GL definitions from "unix" platform. Also made CC definition conditional, as it prevented cross-compiling.