### PR TITLE
Add color option.

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -87,6 +87,17 @@ struct retro_core_option_definition option_defs_us[] = {
            { "7", NULL },
            { "8", NULL },
            { "9", NULL },
+           { "10", NULL },
+           { "11", NULL },
+           { "12", NULL },
+           { "13", NULL },
+           { "14", NULL },
+           { "15", NULL },
+           { "16", NULL },
+           { "17", NULL },
+           { "18", NULL },
+           { "19", NULL },
+           { "20", NULL },
            { NULL, NULL }
        },
        "4"
@@ -108,6 +119,22 @@ struct retro_core_option_definition option_defs_us[] = {
            { NULL, NULL }
        },
        "4"
+   },
+   {
+       "vecx_line_color",
+       "Line color",
+       "Color of the line.",
+       {
+           { "White", NULL },
+           { "Green", NULL },
+           { "Cyan", NULL },
+           { "Yellow", NULL },
+           { "Magenta", NULL },
+           { "Red", NULL },
+           { "Blue", NULL },
+           { NULL, NULL }
+       },
+       "White"
    },
    {
        "vecx_bloom_brightness",


### PR DESCRIPTION
Add a core option to change line color.

Also add more line brightness levels to achieve the "over exposure" effect (bright spots become nearly white, while the "glow" remains in color).

Some screenshots:

![image](https://github.com/libretro/libretro-vecx/assets/64153870/b56ca918-c659-4332-bbe7-160e97281a4a)

![image](https://github.com/libretro/libretro-vecx/assets/64153870/133c3e46-1c1a-45eb-a4dc-3963a70cfeea)

![image](https://github.com/libretro/libretro-vecx/assets/64153870/2582a49c-3f34-4f98-8f79-66d0c19aa7dd)
