### PR TITLE
Add modern GLVND support for UNIX platform

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,6 +1,7 @@
 DEBUG=0
 FRONTEND_SUPPORTS_RGB565=1
 HAS_GPU ?= 1
+USE_GLVND ?= 0
 
 ifeq ($(platform),)
    platform = unix
@@ -64,6 +65,8 @@ ifeq ($(platform), unix)
       ifeq ($(HAS_GLES), 1)
          GL_LIB := -lGLESv2
          GLES :=1
+      else ifeq ($(USE_GLVND), 1)
+         GL_LIB := -lOpenGL
       else
          GL_LIB := -lGL
       endif


### PR DESCRIPTION
On GLVND Linux systems without X11 compilation would fail with:

> /bin/ld.gold: error: cannot find -lGL

This PR fixes it by adding USE_GLVND option.